### PR TITLE
Modenize NVIDIA driver installer invocation to the version 410 era

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,17 @@
 FROM ubuntu:17.10
 
 RUN apt-get update && \
-    apt-get install -y kmod gcc make curl xz-utils bc libelf-dev libssl-dev && \
+    apt-get install -y \
+        bc \
+        curl \
+        gcc \
+        kmod \
+        libelf-dev \
+        libssl-dev \
+        make \
+        perl-modules \
+        xz-utils \
+        && \
     rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
More recent versions of the NVIDIA driver installer have a significantly changed interface, rendering the previous set of flags employed here obsolete. Adjust the invocation of the installer to meet
its new interface, as well as the default URL template by which it can be downloaded. It is hard to tell to what extent we can generalize the current URL into a template; there are "10.0" and "10.0.130" path components that could change with each driver version change.

Note that we don't attempt to retain compatibility with the previous installer interface. It's not possible to change just the "NVIDIA_DRIVER_VERSION" variable back to, say, "396.26" and install that version instead. Accommodating both of these known installer interfaces (and any in between) would entail surveying each version's installer to learn which changes in interfaces occurred when.

As far as I can tell, there's no longer any way to push the value of the "NVIDIA_INSTALL_DIR_CONTAINER" through to the installer. Fortunately, the default value—_/usr/local/nvidia_—matches the default value for the variable in the _entrypoint.sh_ file, but if callers had been customizing that variable, I don't think the installer can honor their choice any longer.

Note too that recent versions of the NVIDIA installer now require the _Tie::File_
Perl module, so I added that and sorted the installed package list to make adjusting it in the future a little easier.

Fixes #4.