### PR TITLE
Supply missing bison and flex dependencies for kernel source configuration step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:17.10
+FROM ubuntu:18.10
 
 RUN apt-get update && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM ubuntu:18.10
 RUN apt-get update && \
     apt-get install -y \
         bc \
+        bison \
         curl \
         gcc \
         kmod \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
         bc \
         bison \
         curl \
+        flex \
         gcc \
         kmod \
         libelf-dev \


### PR DESCRIPTION
My recent attempts to install the drivers using the Docker container image failed due to two tools found missing during the "Configuring kernel sources" step: _bison_ and _flex_. I don't know whether this dependency is new in more recent kernel versions, or if we had those tools before and lost them (I don't see how that could have happened). In any case, installing them explicitly now allows the rest of the driver installation procedure to complete successfully.